### PR TITLE
Increase health check start_period and timeout

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,9 +18,9 @@ services:
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s = socket.create_connection(('localhost', 8420), timeout=2); s.close()"]
       interval: 10s
-      timeout: 5s
+      timeout: 10s
       retries: 3
-      start_period: 5s
+      start_period: 15s
 
   # Named tunnel — stable URL at awareness.intfar.com
   # Requires: cloudflared tunnel login + tunnel create (see Deployment Guide)


### PR DESCRIPTION
## Summary

- `start_period` 5s → 15s — gives the server more time to boot before health checks count
- `timeout` 5s → 10s — prevents intermittent timeout failures during normal operation

Observed the container reporting unhealthy on startup due to health check timeouts, which caused the tunnel dependency to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)