### PR TITLE
Switch production deployment to Postgres backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY src/ src/
 
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir ".[postgres]"
 
 ENV AWARENESS_DATA_DIR=/app/data
 ENV AWARENESS_TRANSPORT=streamable-http

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,11 @@ services:
     environment:
       - AWARENESS_DATA_DIR=/app/data
       - AWARENESS_MOUNT_PATH=${AWARENESS_MOUNT_PATH:-}
+      - AWARENESS_BACKEND=${AWARENESS_BACKEND:-sqlite}
+      - AWARENESS_DATABASE_URL=${AWARENESS_DATABASE_URL:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
     deploy:
       resources:
         limits:
@@ -42,8 +47,7 @@ services:
           cpus: '0.05'
           memory: 64M
 
-  # PostgreSQL backend — opt-in via: docker compose --profile postgres up -d
-  # Then set AWARENESS_BACKEND=postgres and AWARENESS_DATABASE_URL in .env
+  # PostgreSQL backend (default when AWARENESS_BACKEND=postgres in .env)
   postgres:
     image: pgvector/pgvector:pg17
     container_name: awareness-postgres
@@ -73,8 +77,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
-    profiles:
-      - postgres
 
   # Quick tunnel — ephemeral URL, no account needed
   # Usage: docker compose up mcp-awareness tunnel-quick

--- a/src/mcp_awareness/store.py
+++ b/src/mcp_awareness/store.py
@@ -111,8 +111,6 @@ class SQLiteStore:
             CREATE INDEX IF NOT EXISTS idx_entries_type ON entries(type);
             CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source);
             CREATE INDEX IF NOT EXISTS idx_entries_type_source ON entries(type, source);
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_entries_source_logical_key
-                ON entries(source, logical_key) WHERE logical_key IS NOT NULL;
         """)
         # Migrations for existing databases
         cur = self._conn.execute("PRAGMA table_info(entries)")
@@ -121,10 +119,11 @@ class SQLiteStore:
             self._conn.execute("ALTER TABLE entries ADD COLUMN deleted TEXT")
         if "logical_key" not in columns:
             self._conn.execute("ALTER TABLE entries ADD COLUMN logical_key TEXT")
-            self._conn.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_entries_source_logical_key "
-                "ON entries(source, logical_key) WHERE logical_key IS NOT NULL"
-            )
+        # Always ensure the index exists (covers both fresh and migrated DBs)
+        self._conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_entries_source_logical_key "
+            "ON entries(source, logical_key) WHERE logical_key IS NOT NULL"
+        )
         self._conn.commit()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Dockerfile**: `pip install ".[postgres]"` — includes psycopg in the Docker image
- **docker-compose**: Postgres service runs by default (removed `profiles: postgres`), mcp-awareness depends on postgres health check, backend env vars passed through
- **SQLite migration fix**: `logical_key` index creation moved after column migration to prevent errors on existing databases

## QA: Manual testing steps

### Prerequisites

- [x] This branch checked out
- [x] `.env` has `AWARENESS_BACKEND=postgres` and `AWARENESS_DATABASE_URL`

### 1. Build and deploy

```bash
docker compose build && docker compose up -d
```

- [x] All three containers healthy (postgres, mcp-awareness, tunnel)
- [x] `docker logs mcp-awareness` shows "Uvicorn running"

### 2. Verify endpoint

```bash
curl -s -o /dev/null -w "%{http_code}" https://mcpawareness.com/mcp
```

- [x] Returns 403 (WAF blocking, server is live)

### 3. Verify data migrated

Connect via any MCP client and call `get_stats`.

- [x] Entry counts match pre-migration SQLite data

## Automated tests

- [x] 155 tests pass
- [x] Already deployed and verified on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)