### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-03-22
 
 ### Added
 - **Alembic migrations**: version-tracked database migrations for PostgreSQL (raw SQL, no ORM)
@@ -117,7 +117,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/cmeans/mcp-awareness/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/cmeans/mcp-awareness/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/cmeans/mcp-awareness/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/cmeans/mcp-awareness/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
## Summary
- Rename `[Unreleased]` → `[0.4.0] - 2026-03-22` in CHANGELOG.md
- Add `[Unreleased]` comparison link pointing from v0.4.0 to HEAD
- Add `[0.4.0]` comparison link pointing from v0.3.1 to v0.4.0

## Test plan
- [x] CHANGELOG formatting follows Keep a Changelog
- [x] Comparison links are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)