### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.1] - 2026-03-22
 
 ### Fixed
 - **Cleanup error logging**: `_do_cleanup` now logs exceptions instead of silently swallowing them (both SQLite and Postgres backends)
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Pagination**: `limit`/`offset` params on `get_knowledge`, `get_alerts`, `get_entries`, `get_deleted` tools and Store protocol methods
+- **QA gate**: `QA Approved` label required to merge PRs, enforced by `qa-gate.yml` workflow (pending status, not failed)
+- QA section conventions in CLAUDE.md: MCP-based manual tests with copyable code blocks
 - 7 new tests (162 total)
 
 ## [0.4.0] - 2026-03-22
@@ -127,7 +129,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/cmeans/mcp-awareness/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/cmeans/mcp-awareness/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/cmeans/mcp-awareness/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/cmeans/mcp-awareness/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ See [Security considerations](docs/deployment-guide.md#security-considerations) 
 - Three-layer detection model (threshold + knowledge implemented; baseline planned)
 - Suppression system with time-based expiry and escalation overrides
 - Alembic migration framework for PostgreSQL (version-tracked, raw SQL, auto-runs on Docker startup)
+- Pagination (`limit`/`offset`) on knowledge, alerts, entries, and trash queries
+- QA gate: `QA Approved` label required to merge PRs (pending status, not failed)
 - 162 tests, strict type checking, CI pipeline
 
 **Not yet implemented:**


### PR DESCRIPTION
## Summary
- Rename `[Unreleased]` → `[0.4.1] - 2026-03-22` in CHANGELOG
- Add QA gate and pagination to CHANGELOG entries
- Add pagination and QA gate to README Implemented section
- Update comparison links

## QA

### Manual tests (via MCP tools)
1. - [ ] **Verify changelog formatting**
   Inspect CHANGELOG.md — `[0.4.1]` section exists with Fixed and Added subsections, comparison link points to `v0.4.0...v0.4.1`

2. - [ ] **Verify README**
   Inspect README.md — "Implemented" section includes pagination and QA gate lines, test count is 162

🤖 Generated with [Claude Code](https://claude.com/claude-code)