### PR TITLE
Release v0.5.0 — MCP prompts, one-line demo install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-03-23
+
 ### Added
 - **MCP Prompts** — 5 dynamic prompts built from store data:
   - `agent_instructions` — complete workflow conventions from `source="awareness-prompt"` entries
@@ -147,7 +149,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/cmeans/mcp-awareness/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/cmeans/mcp-awareness/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/cmeans/mcp-awareness/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/cmeans/mcp-awareness/compare/v0.3.0...v0.3.1


### PR DESCRIPTION
## Summary

**v0.5.0 is the biggest release yet.** Two major features land together: MCP Prompts and the one-line demo install.

### MCP Prompts
Your AI now gets dynamic, data-driven prompts built from what's actually in your awareness store — not static instructions you have to maintain by hand. Five built-in prompts (`agent_instructions`, `project_context`, `system_status`, `write_guide`, `catchup`) generate content on the fly. And you can create your own: store an entry with `source="custom-prompt"`, use `{{var}}` placeholders for arguments, and it appears as a prompt in any client that supports them. No code changes, no redeployment.

### One-line demo install
```bash
curl -sSL https://raw.githubusercontent.com/cmeans/mcp-awareness/main/install-demo.sh | bash
```
One command. Three containers (Awareness server, Postgres, Cloudflare tunnel). A public URL. Config snippets for every major MCP client. Pre-loaded demo data that teaches itself — including a `getting-started` prompt that interviews you and personalizes your instance. From zero to "my AI knows me" in under a minute.

### Also in this release
- **Published Docker image** on GHCR (`ghcr.io/cmeans/mcp-awareness`) — auto-built on every version tag
- **Delete and restore by tags** with AND logic — `delete_entry(tags=["demo"], confirm=True)` cleans up exactly what you want
- **Dockerfile hardened** — non-root `awareness` user, OCI image labels, no anonymous volumes
- **Docs overhauled** — deployment guide rewritten for all MCP clients (not just Claude.ai), README reorganized

### 208 unique cloners this week
People aren't just looking — they're cloning. This release makes their first experience dramatically better.

## QA
Changelog-only commit. All code QA'd and merged via PR #27 (MCP prompts) and PR #28 (one-line demo install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)