### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-03-23
+
 ### Added
 - **List mode**: `get_knowledge(mode="list")` returns metadata only (id, type, source, description, tags, created, updated) — no content or changelog. Also available on `get_alerts` and `get_deleted`. Use to orient before pulling full entries.
 - **Since filter**: `get_knowledge(since="2026-03-23T06:00:00Z")` returns only entries updated after the given timestamp. SQL-level filtering (not post-query). Also available on `get_alerts`, `get_entries`, and `get_deleted`.
@@ -176,7 +178,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/cmeans/mcp-awareness/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/cmeans/mcp-awareness/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/cmeans/mcp-awareness/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/cmeans/mcp-awareness/compare/v0.3.1...v0.4.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ name: mcp-awareness
 
 services:
   mcp-awareness:
-    image: ghcr.io/cmeans/mcp-awareness:0.5.0
+    image: ghcr.io/cmeans/mcp-awareness:0.6.0
     # For local development, comment out 'image' and uncomment 'build':
     # build: .
     container_name: mcp-awareness


### PR DESCRIPTION
## Summary
- Rename [Unreleased] → [0.6.0] in CHANGELOG
- Update comparison links
- Update docker-compose.yaml image tag to 0.6.0

## QA
Release housekeeping only — no code changes. PR #30 was fully QA'd (190 tests, manual MCP tool testing, 3 review rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)