### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-03-23
+
 ### Added
 - **INTENTION entry type**: Goals with constraints, evaluated when conditions align. New lifecycle: pending → fired → completed/snoozed/cancelled.
 - **`remind` tool**: Create intentions with optional `deliver_at` timestamp, constraints, urgency. Time-based triggers fire automatically in the briefing.
@@ -207,7 +209,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/cmeans/mcp-awareness/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/cmeans/mcp-awareness/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/cmeans/mcp-awareness/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/cmeans/mcp-awareness/compare/v0.5.0...v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-awareness-server"
-version = "0.7.0"
+version = "0.8.0"
 description = "Generic MCP server for ambient system awareness across monitored systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Rename [Unreleased] → [0.8.0] in CHANGELOG
- Update comparison links
- Bump pyproject.toml to 0.8.0

## QA
Release housekeeping only — no code changes. PR #35 was fully QA'd (231 tests, 9 manual MCP tool tests, 2 review rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)