### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-03-23
+
 ### Changed
 - **SQL-level pagination**: LIMIT/OFFSET pushed from Python to SQL in `_query_entries`. All list methods (`get_entries`, `get_knowledge`, `get_active_alerts`, `get_deleted`, `get_intentions`) now paginate at the database level.
 - **Default sort order**: All queries return most recently updated entries first (`ORDER BY updated DESC`). Previously returned oldest first.
@@ -224,7 +226,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/cmeans/mcp-awareness/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/cmeans/mcp-awareness/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/cmeans/mcp-awareness/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/cmeans/mcp-awareness/compare/v0.6.0...v0.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-awareness-server"
-version = "0.8.0"
+version = "0.9.0"
 description = "Generic MCP server for ambient system awareness across monitored systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Rename [Unreleased] → [0.9.0] in CHANGELOG
- Update comparison links
- Bump pyproject.toml to 0.9.0

## QA
Release housekeeping only — no code changes. PR #37 was fully QA'd (239 tests, 7 manual MCP tool tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)