### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-03-23
+
 ### Added
 - **Semantic search (RAG)**: New `semantic_search` tool finds entries by meaning using vector similarity. Powered by pgvector + Ollama (optional, self-hosted).
 - **Embedding provider abstraction**: `EmbeddingProvider` protocol with `OllamaEmbedding` and `NullEmbedding` implementations. Swappable backends.
@@ -240,7 +242,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/cmeans/mcp-awareness/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/cmeans/mcp-awareness/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/cmeans/mcp-awareness/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/cmeans/mcp-awareness/compare/v0.6.1...v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-awareness-server"
-version = "0.9.0"
+version = "0.10.0"
 description = "Generic MCP server for ambient system awareness across monitored systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Rename `[Unreleased]` → `[0.10.0] - 2026-03-23`
- Bump version in pyproject.toml to 0.10.0
- Update comparison links

## QA

### Prerequisites
- None — version bump only

### Manual tests (via MCP tools)
1. - [ ] **Verify version**: `pip install -e . && python -c "from mcp_awareness import __version__; print(__version__)"` → `0.10.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)