### PR TITLE
Auto-pull embedding model on Ollama startup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ name: mcp-awareness
 
 services:
   mcp-awareness:
-    image: ghcr.io/cmeans/mcp-awareness:0.9.0
+    image: ghcr.io/cmeans/mcp-awareness:0.10.0
     # For local development, comment out 'image' and uncomment 'build':
     # build: .
     container_name: mcp-awareness
@@ -87,11 +87,24 @@ services:
 
   # Ollama — local embedding model for semantic search
   # Usage: docker compose --profile embeddings up -d
-  # Then: docker exec awareness-ollama ollama pull nomic-embed-text
+  # Model is pulled automatically on first start (cached in volume for restarts).
   ollama:
     image: ollama/ollama:latest
     container_name: awareness-ollama
     restart: unless-stopped
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        # Start Ollama server in background
+        ollama serve &
+        # Wait for server to be ready
+        until ollama list > /dev/null 2>&1; do sleep 1; done
+        # Pull model if not already cached
+        ollama pull ${AWARENESS_EMBEDDING_MODEL:-nomic-embed-text}
+        # Keep container alive (wait on background server)
+        wait
+    environment:
+      - AWARENESS_EMBEDDING_MODEL=${AWARENESS_EMBEDDING_MODEL:-nomic-embed-text}
     volumes:
       - ${AWARENESS_OLLAMA_DATA:-~/awareness-ollama}:/root/.ollama
     deploy:
@@ -100,11 +113,11 @@ services:
           cpus: '1.0'
           memory: 2G
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:11434/api/tags"]
+      test: ["CMD-SHELL", "ollama list | grep -q ${AWARENESS_EMBEDDING_MODEL:-nomic-embed-text}"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 30s
+      retries: 10
+      start_period: 60s
     profiles:
       - embeddings
 


### PR DESCRIPTION
## Summary
- Ollama container now auto-pulls the configured embedding model on first start
- No manual `docker exec awareness-ollama ollama pull nomic-embed-text` needed
- Model cached in volume — subsequent restarts are instant
- Healthcheck verifies model is loaded (not just API responding)

## QA

### Prerequisites
- Remove existing Ollama volume to test fresh start: `docker volume rm mcp-awareness_awareness-ollama` (or rename `~/awareness-ollama`)

### Manual tests
1. - [x] **Fresh start pulls model automatically**
   ```
   docker compose --profile embeddings up -d ollama
   docker logs -f awareness-ollama
   ```
   Expected: logs show model pull, container reaches healthy status

2. - [x] **Healthcheck confirms model loaded**
   ```
   docker ps --filter name=awareness-ollama
   ```
   Expected: status shows `(healthy)` after model pull completes

3. - [x] **Restart uses cached model (fast)**
   ```
   docker compose restart ollama
   ```
   Expected: healthy in seconds, no re-download

🤖 Generated with [Claude Code](https://claude.com/claude-code)
