### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-03-24
+
 ### Added
 - **Background embedding generation**: Write tools now submit embedding generation to a thread pool (max 2 workers) instead of blocking the response. ~100-200ms latency removed from writes.
 - **`backfill_embeddings` tool**: Embeds entries created before the provider was configured, and re-embeds entries whose content changed since their last embedding (stale detection via `text_hash`).
@@ -254,7 +256,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/cmeans/mcp-awareness/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/cmeans/mcp-awareness/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/cmeans/mcp-awareness/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/cmeans/mcp-awareness/compare/v0.7.0...v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-awareness-server"
-version = "0.10.0"
+version = "0.11.0"
 description = "Generic MCP server for ambient system awareness across monitored systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Rename `[Unreleased]` → `[0.11.0] - 2026-03-24`
- Bump version in pyproject.toml to 0.11.0
- Update comparison links

## QA

### Prerequisites
- None — version bump only

### Manual tests (via MCP tools)
1. - [x] **Verify version**: `pip install -e . && python -c "from mcp_awareness import __version__; print(__version__)"` → `0.11.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)