### PR TITLE
Add planned edge providers section to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Planned edge providers** section in README: documents five provider categories (Calendar, GPS, NAS, Health, Vision) with multi-edge correlation design
+
 ### Changed
 - **Tool description heuristics**: Rewritten docstrings for `remember`, `add_context`, `learn_pattern`, and `remind` with decision heuristics that help agents choose the right tool. Each includes a "quick test" rule: still true in 30 days? → `remember`. Happening now, will become stale? → `add_context`. Has a "when X, expect Y" rule? → `learn_pattern`. `remind` language softened from formal "intentions" to friendlier "todos, reminders, and planned actions."
 - **Connection pooling**: `PostgresStore` now uses `psycopg_pool.ConnectionPool` (min 2, max 5 connections) instead of a single shared connection. Concurrent HTTP requests no longer serialize. Background threads (embedding, cleanup) draw from the pool instead of needing dedicated connections. The hand-rolled `_conn` health check property is removed — the pool handles reconnection, health checks, and connection recycling automatically.

--- a/README.md
+++ b/README.md
@@ -319,8 +319,21 @@ See [Security considerations](docs/deployment-guide.md#security-considerations) 
 
 ### Not yet implemented
 - Layer 2 (baseline) detection — rolling averages and deviation calculation
-- Edge processes — no automated producers yet ([example script](examples/simulate_edge.py) demonstrates the write path)
 - OAuth / API key authentication — current auth is secret-path-based
+
+### Planned edge providers
+
+Edge providers are lightweight processes that monitor external systems and write knowledge into awareness. Each is simple alone; the server correlates them into well-timed, actionable intelligence. No automated producers yet ([example script](examples/simulate_edge.py) demonstrates the write path).
+
+| Provider | Source | What it writes |
+|----------|--------|----------------|
+| **Google Calendar** | GCal API (polling) | Today's events as `add_context` entries. Any agent knows your schedule without direct calendar access. |
+| **GPS / Location** | Phone (Tasker/Shortcuts) | Current coordinates. Triggers location-based intentions, corroborates meeting attendance, auto-completes travel intentions. |
+| **NAS / Infrastructure** | Synology, Proxmox | Disk health, container status, backup state. The original monitoring use case. |
+| **Health / Wearable** | Garmin, Apple Health | Sleep, HRV, activity. Cross-domain correlations (sleep quality vs. productivity). |
+| **Home Assistant / Vision** | HA + cameras (RPi, GoPro) | Household state detection — trash accumulation, packages at door, laundry pile. Paired with calendar: "trash building up + leaving by car → take it down, leave 5 min early." |
+
+**Multi-edge correlation** is where the real value lives. No single edge makes decisions alone — calendar provides the *expectation*, GPS provides the *evidence*, vision provides the *trigger*, and the server reconciles them into intentions that self-resolve through the lifecycle: pending → active → completed, with minimal user intervention.
 
 ## Vision
 


### PR DESCRIPTION
## Summary
- Add "Planned edge providers" section to README documenting five provider categories: Calendar, GPS/Location, NAS/Infrastructure, Health/Wearable, Home Assistant/Vision
- Each provider listed with source, what it writes, and concrete examples
- Highlights multi-edge correlation as the key differentiator — simple edges compose into actionable intelligence
- Update CHANGELOG

This is docs-only — no code changes.

## QA

### Prerequisites
- None (docs-only PR)

### Manual tests (via MCP tools)
1. - [x] **Verify README renders correctly**
   ```
   Review the Planned edge providers table on the PR diff or rendered README
   ```
   Expected: table renders with 5 providers, multi-edge correlation paragraph below

2. - [x] **Verify edge provider examples are concrete and accurate**
   ```
   Review each provider description against existing awareness entries and project docs
   ```
   Expected: descriptions match the designs logged in awareness (calendar edge, GPS lifecycle, vision-based household detection)


🤖 Generated with [Claude Code](https://claude.com/claude-code)