### PR TITLE
Release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-03-24
+
 ### Fixed
 - **`parse_iso` naive datetime**: Inputs without timezone suffix now default to UTC instead of returning naive datetimes that cause `TypeError` on comparison
 - **`count_active_suppressions` missing expiry filter**: Now excludes expired suppressions, consistent with `get_active_suppressions`
@@ -274,7 +276,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/cmeans/mcp-awareness/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/cmeans/mcp-awareness/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/cmeans/mcp-awareness/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/cmeans/mcp-awareness/compare/v0.8.0...v0.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-awareness-server"
-version = "0.11.0"
+version = "0.11.1"
 description = "Generic MCP server for ambient system awareness across monitored systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Version stamp only — all code was tested and QA'd in PRs #45–#49.

### What's in v0.11.1
- **5 bug fixes**: parse_iso naive datetime, count_active_suppressions expiry, get_knowledge filter bypass, delete_entry dry-run mismatch, embedding text missing entry type
- **Input validation**: enum parameters + bounds checking
- **Tool description heuristics**: decision rules for remember/add_context/learn_pattern/remind
- **Connection pooling**: psycopg_pool (min 2, max 5)
- **Edge providers docs**: README section with 5 provider categories
- **15 new tests** (318 → 333)
- **Flaky test fix**: test_expired_entries_cleaned polling instead of fixed sleep

## QA
Release PR — version stamp only. All code already QA'd in feature PRs.


🤖 Generated with [Claude Code](https://claude.com/claude-code)