### PR TITLE
Add query discipline to server instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Query discipline in server instructions**: MCP instructions now guide clients to use `mode='list'` before full fetches, set `limit`, use `hint` for relevance ranking, narrow with specific tags, and check `get_stats`/`get_tags` before broad queries
+- **Externalized server instructions**: MCP instructions moved from inline Python string to `instructions.md` for cleaner content/code separation
 
 ### Changed
 - **README aspirational claims**: Replaced doctor appointment scenario with grounded cross-platform example, qualified "family schedules, health data" as planned edge capabilities, reframed intentions section around working features (time-based firing) with location-based noted as planned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcp_awareness"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/mcp_awareness/instructions.md" = "mcp_awareness/instructions.md"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/mcp_awareness/instructions.md
+++ b/src/mcp_awareness/instructions.md
@@ -1,0 +1,19 @@
+This server provides ambient awareness across monitored systems.
+At conversation start, read awareness://briefing. If attention_needed
+is true, mention the suggested_mention or compose your own from the
+source headlines. If the user asks for details, drill into the
+referenced resources. Don't read anything else unless asked or unless
+the briefing indicates an issue. Group alerts by source if multiple
+systems have issues. One sentence for warnings, short paragraph for
+critical. Don't re-check unless asked. When you learn something worth
+keeping, use remember for permanent facts, add_context for temporal
+events, and learn_pattern ONLY for if/then rules (when X, expect Y).
+When the user asks to suppress alerts, use suppress_alert — not a
+memory edit.
+
+Query discipline: before pulling full entries, call get_knowledge with
+mode='list' to scan metadata. Always set limit (e.g., 10–20) to avoid
+unbounded results. Use hint to re-rank by relevance so the best matches
+come first. Narrow with 2–3 specific tags rather than one broad tag.
+Use since/until for time-bounded queries. Call get_stats or get_tags
+first if you're unsure how much data exists.

--- a/src/mcp_awareness/server.py
+++ b/src/mcp_awareness/server.py
@@ -11,6 +11,7 @@ import concurrent.futures
 import functools
 import json
 import os
+import pathlib
 import re
 import time
 from collections.abc import Callable
@@ -207,30 +208,14 @@ def _timed(fn: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
+_INSTRUCTIONS_PATH = pathlib.Path(__file__).parent / "instructions.md"
+_INSTRUCTIONS = _INSTRUCTIONS_PATH.read_text(encoding="utf-8").strip()
+
 mcp = FastMCP(
     name="mcp-awareness",
     host=HOST,
     port=PORT,
-    instructions=(
-        "This server provides ambient awareness across monitored systems. "
-        "At conversation start, read awareness://briefing. If attention_needed "
-        "is true, mention the suggested_mention or compose your own from the "
-        "source headlines. If the user asks for details, drill into the "
-        "referenced resources. Don't read anything else unless asked or unless "
-        "the briefing indicates an issue. Group alerts by source if multiple "
-        "systems have issues. One sentence for warnings, short paragraph for "
-        "critical. Don't re-check unless asked. When you learn something worth "
-        "keeping, use remember for permanent facts, add_context for temporal "
-        "events, and learn_pattern ONLY for if/then rules (when X, expect Y). "
-        "When the user asks to suppress alerts, use suppress_alert — not a "
-        "memory edit. "
-        "Query discipline: before pulling full entries, call get_knowledge with "
-        "mode='list' to scan metadata. Always set limit (e.g., 10–20) to avoid "
-        "unbounded results. Use hint to re-rank by relevance so the best matches "
-        "come first. Narrow with 2–3 specific tags rather than one broad tag. "
-        "Use since/until for time-bounded queries. Call get_stats or get_tags "
-        "first if you're unsure how much data exists."
-    ),
+    instructions=_INSTRUCTIONS,
 )
 
 


### PR DESCRIPTION
## Summary
- Add query discipline guidance to MCP server instructions — teaches all clients to use `mode='list'` before full fetches, set `limit`, use `hint` for relevance, narrow with specific tags, and check `get_stats`/`get_tags` before broad queries
- Externalize server instructions from inline Python string to `instructions.md` for content/code separation
- Update `pyproject.toml` to include `instructions.md` in wheel builds
- Triggered by a 356K-char `get_knowledge` result that blew the tool output limit during PR #52 review

## QA

### Prerequisites
- `pip install -e ".[dev]"`
- Deploy to test instance on alternate port (`AWARENESS_PORT=8421`)

### Manual tests (via MCP tools)
1. - [x] **Verify server instructions include query discipline**
   Connect to the test instance and inspect the server's MCP instructions (visible in client connection metadata or via `mcp.get_server_info()`). Confirm the instructions contain "Query discipline:" guidance covering mode=list, limit, hint, tags, and get_stats/get_tags.

2. - [x] **Verify existing instruction behavior unchanged**
   ```
   get_briefing()
   ```
   Expected: briefing returns normally — existing instruction guidance (briefing at start, suppress_alert, remember/add_context/learn_pattern) still present and functional.

3. - [x] **Verify instructions.md loads at startup**
   Start the server and confirm no `FileNotFoundError` or missing instructions. The instructions should be identical to the content in `src/mcp_awareness/instructions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)