### PR TITLE
Fix catchup prompt loading all entries into memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Catchup prompt now pushes `since` filter to SQL instead of loading all entries into Python
+
 ### Added
 - **Branding assets**: 9 SVG logo variants (icon sizes 16–200px, light/dark, wordmark light/dark) and favicon.ico in `docs/branding/`
 - **README logo header**: Wordmark hero replaces plain `# mcp-awareness` heading, centered badge row

--- a/src/mcp_awareness/server.py
+++ b/src/mcp_awareness/server.py
@@ -1519,12 +1519,8 @@ async def write_guide() -> str:
 async def catchup(hours: int = 24) -> str:
     """Compose a catchup summary of recently updated entries."""
     since = now_utc() - timedelta(hours=hours)
-    # Pull all knowledge and filter by updated timestamp
-    all_entries = store.get_knowledge(include_history="true")
-    recent = [e for e in all_entries if e.updated >= since]
-    # Also check alerts
-    alerts = store.get_active_alerts()
-    recent_alerts = [a for a in alerts if a.updated >= since]
+    recent = store.get_knowledge(include_history="true", since=since)
+    recent_alerts = store.get_active_alerts(since=since)
 
     parts: list[str] = [f"# Catchup — last {hours} hours"]
 


### PR DESCRIPTION
## Summary
- The `catchup` prompt was calling `get_knowledge()` and `get_active_alerts()` without a `since` parameter, loading all entries into Python and filtering in-memory
- Both methods already accept a `since` parameter that pushes the filter to SQL — this PR passes it through
- Prevents linear performance degradation as the knowledge store grows

## QA

### Prerequisites
- `pip install -e ".[dev]"`
- Deploy to test instance on alternate port (`AWARENESS_PORT=8421`)

### Manual tests (via MCP tools)
1. - [x] **Seed entries at different ages**
   ```
   remember(source="qa-test", description="Old entry created well before window", tags=["qa-catchup"])
   ```
   Wait a moment, then:
   ```
   remember(source="qa-test", description="Recent entry created within window", tags=["qa-catchup"])
   ```
   Expected: Two entries exist in the store with different `updated` timestamps

2. - [x] **Verify catchup filters correctly**
   Invoke the `catchup` prompt with a small time window (e.g., `hours=1`).
   Expected: Only entries updated within the last hour appear. The old entry (if created more than 1 hour ago) should not appear. If both are recent, both appear — the key is that the filtering happens server-side (verify via query logs or by checking that entries outside the window are excluded).

3. - [x] **Verify catchup with default window**
   Invoke the `catchup` prompt with default parameters (no `hours` argument).
   Expected: Returns entries updated in the last 24 hours, grouped by source, with `[new]` or `[updated]` markers.

4. - [x] **Verify empty catchup**
   Invoke the `catchup` prompt with `hours=0`.
   Expected: Returns "Nothing changed. You're up to date." since no entries were updated in the last 0 hours.

5. - [x] **Cleanup**
   ```
   delete_entry(source="qa-test", tags=["qa-catchup"], confirm=true)
   ```
   Expected: Test entries removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)