### PR TITLE
Add debug logging to fire-and-forget exception handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Replace silent `except Exception: pass` blocks with `logger.debug` logging in server and store
 - `upsert_by_logical_key` race condition: concurrent writers can no longer create duplicate entries
 - Logical key unique index now excludes soft-deleted entries, allowing re-creation after delete
 - Invalid `entry_type` parameter now returns structured error instead of unhandled ValueError

--- a/src/mcp_awareness/postgres_store.py
+++ b/src/mcp_awareness/postgres_store.py
@@ -10,6 +10,7 @@ Requires: pip install psycopg[binary] psycopg_pool
 from __future__ import annotations
 
 import json
+import logging
 import threading
 import time
 from datetime import datetime, timedelta, timezone
@@ -20,6 +21,8 @@ from psycopg.rows import dict_row
 from psycopg_pool import ConnectionPool
 
 from .schema import Entry, EntryType, ensure_dt, ensure_dt_optional, make_id, now_utc, to_iso
+
+logger = logging.getLogger(__name__)
 
 # How long soft-deleted entries remain recoverable before auto-purge
 TRASH_RETENTION_DAYS = 30
@@ -743,7 +746,7 @@ class PostgresStore:
                         (eid, platform, tool_used),
                     )
         except Exception:
-            pass  # Fire-and-forget
+            logger.debug("log_read failed", exc_info=True)
 
     def log_action(
         self,

--- a/src/mcp_awareness/server.py
+++ b/src/mcp_awareness/server.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import concurrent.futures
 import functools
 import json
+import logging
 import os
 import pathlib
 import re
@@ -31,6 +32,8 @@ from .embeddings import (
 from .postgres_store import PostgresStore
 from .schema import Entry, EntryType, ensure_dt, make_id, now_utc, parse_iso, to_iso
 from .store import Store
+
+logger = logging.getLogger(__name__)
 
 _start_time = time.monotonic()
 
@@ -179,7 +182,7 @@ def _do_embed(
                 )
                 conn.commit()
     except Exception:
-        pass  # Backfill will catch failures
+        logger.debug("Embedding failed for entry %s", entry_id, exc_info=True)
 
 
 def _generate_embedding(entry: Entry) -> None:
@@ -199,7 +202,7 @@ def _log_reads(entries: list[Any], tool_name: str) -> None:
         if ids:
             store.log_read(ids, tool_used=tool_name)
     except Exception:
-        pass  # Read logging must never break the tool response
+        logger.debug("Read logging failed for %s", tool_name, exc_info=True)
 
 
 def _log_timing(tool_name: str, elapsed_ms: float) -> None:
@@ -461,7 +464,7 @@ async def get_knowledge(
                     # entries without embeddings at the end
                     entries.sort(key=lambda e: similarity_map.get(e.id, -1.0), reverse=True)
             except Exception:  # pragma: no cover
-                pass  # Fall back to default ordering
+                logger.debug("Hint re-ranking failed", exc_info=True)
 
     if mode == "list":
         read_counts = store.get_read_counts([e.id for e in entries])
@@ -1261,12 +1264,14 @@ async def backfill_embeddings(
         try:
             vectors = provider.embed(texts)
         except Exception:  # pragma: no cover
+            logger.debug("Backfill embed failed", exc_info=True)
             vectors = []
         for entry, h, vec in zip(missing, hashes, vectors, strict=False):
             try:
                 store.upsert_embedding(entry.id, provider.model_name, provider.dimensions, h, vec)
                 new_count += 1
             except Exception:  # pragma: no cover
+                logger.debug("Backfill upsert failed for entry %s", entry.id, exc_info=True)
                 continue
 
     # Phase 2: stale embeddings (text changed since embedding)
@@ -1278,12 +1283,14 @@ async def backfill_embeddings(
         try:
             vectors = provider.embed(texts)
         except Exception:  # pragma: no cover
+            logger.debug("Backfill refresh embed failed", exc_info=True)
             vectors = []
         for entry, h, vec in zip(stale, hashes, vectors, strict=False):
             try:
                 store.upsert_embedding(entry.id, provider.model_name, provider.dimensions, h, vec)
                 refreshed_count += 1
             except Exception:  # pragma: no cover
+                logger.debug("Backfill refresh upsert failed for entry %s", entry.id, exc_info=True)
                 continue
 
     remaining = len(store.get_entries_without_embeddings(provider.model_name, limit=1))


### PR DESCRIPTION
## Summary
- Replace 6 bare `except Exception: pass` blocks with `logger.debug(..., exc_info=True)` in `server.py` and `postgres_store.py`
- Zero cost when DEBUG is not enabled, but makes systematic failures (e.g., Ollama down) diagnosable
- Adds `import logging` and `logger = logging.getLogger(__name__)` to both modules

## QA

### Prerequisites
- `pip install -e ".[dev]"`
- Deploy to test instance on alternate port (`AWARENESS_PORT=8421`)

### Manual tests (via MCP tools)
1. - [x] **Verify no logging overhead when DEBUG is disabled**
   - Run server with default log level (INFO or higher)
   ```
   remember(source="test", summary="test entry for debug logging", tags=["test"])
   ```
   Expected: No debug output in server logs; tool returns normally

2. - [x] **Verify read logging works normally**
   ```
   get_knowledge(tags=["test"])
   ```
   Expected: Tool returns entries with `read_count` incremented. No debug output at INFO level.

### Notes
- Debug logging in embedding and read-log exception handlers (`_do_embed`, `_log_reads`, `backfill_embeddings`) is only reachable when those operations throw — which requires Ollama to be configured but failing, or DB corruption. These paths are guarded by `# pragma: no cover` and verified by code review, not manual testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)