### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-03-28
+
 ### Changed
 - **License changed from Apache 2.0 to AGPL v3** to protect against proprietary cloud hosting of the codebase. Dual-licensing path preserved for future commercial license.
 
@@ -336,7 +338,8 @@ Initial implementation.
 - **Dockerfile** for container deployment
 - Design docs: core spec and collation layer
 
-[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/cmeans/mcp-awareness/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/cmeans/mcp-awareness/compare/v0.12.0...v0.14.0
 [0.12.0]: https://github.com/cmeans/mcp-awareness/compare/v0.11.2...v0.12.0
 [0.11.2]: https://github.com/cmeans/mcp-awareness/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/cmeans/mcp-awareness/compare/v0.11.0...v0.11.1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 > **Your AI's memory shouldn't be locked to one app. It should follow you everywhere.**
 
 > [!NOTE]
-> Early-stage but actively deployed — 333+ tests, 12+ releases, in daily use across Claude.ai, Claude Code, and Claude Desktop. See [Current status](#current-status) for what's working and what's planned.
+> Early-stage but actively deployed — 383 tests, 14 releases, in daily use across Claude.ai, Claude Code, and Claude Desktop. See [Current status](#current-status) for what's working and what's planned.
 
 ## What this is
 
@@ -347,7 +347,7 @@ See [Security considerations](docs/deployment-guide.md#security-considerations) 
 - Secret path auth + Cloudflare WAF for edge-level access control
 - Docker Compose with Postgres, optional Ollama, named Cloudflare Tunnel, or ephemeral quick tunnel
 - Request timing instrumentation and `/health` endpoint
-- 381 tests (all against real Postgres + Ollama in CI), strict type checking, CI pipeline with coverage, QA gate
+- 383 tests (all against real Postgres + Ollama in CI), strict type checking, CI pipeline with coverage, QA gate
 
 ### Not yet implemented
 - Layer 2 (baseline) detection — rolling averages and deviation calculation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-awareness-server"
-version = "0.12.0"
+version = "0.14.0"
 description = "Generic MCP server for ambient system awareness across monitored systems"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- Version bump to 0.14.0 (skipping 0.13.0)
- CHANGELOG: rename [Unreleased] → [0.14.0] - 2026-03-28, update comparison links
- README: test count 333+ → 383, release count 12+ → 14

All code was tested in feature PRs (#80, #81, #82). This is a version-stamp only.

## QA

Release PR — no manual tests needed per release process convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)