### PR TITLE
Fix on-ci-pass promotion for dependabot PRs

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -102,6 +102,14 @@ jobs:
           PR=$(gh api repos/$REPO/actions/runs/${{ github.event.workflow_run.id }}/pull_requests \
             --jq '.[0].number // empty' 2>/dev/null) || true
 
+          # Fallback: pull_requests array is empty for dependabot and other
+          # non-default-branch PRs. Search by head branch instead.
+          if [ -z "$PR" ]; then
+            HEAD_BRANCH=${{ github.event.workflow_run.head_branch }}
+            PR=$(gh pr list --repo "$REPO" --head "$HEAD_BRANCH" --state open \
+              --json number --jq '.[0].number // empty' 2>/dev/null) || true
+          fi
+
           if [ -z "$PR" ]; then
             echo "No PR associated with this workflow run (may be a fork PR or force-pushed away)"
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PR label automation**: removing `Dev Active` checks CI status (via workflow runs API, job-name-agnostic) and promotes to `Ready for QA` or `Awaiting CI` accordingly
 - **PR label automation**: adding `Dev Active` now also clears `Awaiting CI` and `Ready for QA` to prevent competing state
 - **PR label automation**: added explicit `checks: read` permission
+- **PR label automation**: `on-ci-pass` now finds PRs from dependabot and other non-default branches by falling back to head branch search when the `pull_requests` array is empty
 
 ## [0.14.0] - 2026-03-28
 


### PR DESCRIPTION
## Summary
- `on-ci-pass` silently skipped promotion for dependabot PRs because the `workflow_run.pull_requests` array is empty for non-default-branch PRs (known GitHub limitation)
- Adds fallback: when the array is empty, search open PRs by `workflow_run.head_branch` to find the associated PR
- Fixes the stuck `Awaiting CI` state observed on PRs #85-#88

## QA

### Prerequisites
- Merge this PR, then merge one of the dependabot PRs (#85-#88)
- The remaining dependabot PRs will need rebase — comment `@dependabot rebase`

### Manual tests
1. - [ ] **Dependabot PR auto-promotes after CI**
   After a dependabot PR is rebased and CI passes, verify it transitions from `Awaiting CI` to `Ready for QA` automatically (no manual label change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)