### PR TITLE
Auth exception logging + P1 test gap coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PR label automation**: `on-ci-pass` now finds PRs from dependabot and other non-default branches by falling back to head branch search when the `pull_requests` array is empty
 
 ### Security
+- **Auth exception logging**: `_try_oauth` and `_resolve_user` now log warnings on failure instead of silently swallowing exceptions — operators get visibility into OAuth/user-resolution errors
 - **FORCE ROW LEVEL SECURITY**: RLS policies now enforced on table owner role — previously `ENABLE` without `FORCE` allowed the connection pool role to bypass all policies
 - **UPDATE SQL owner scoping**: `update_entry`, `upsert_alert_update`, `upsert_preference_update` now include `AND owner_id = %s` in WHERE clause — prevents cross-tenant updates
 - **OAuth canonical_email matching**: auto-provisioning and identity linking now use `canonical_email` (strips Gmail dots/+tags) — prevents duplicate accounts from email variants

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 > **Your AI's memory shouldn't be locked to one app. It should follow you everywhere.**
 
 > [!NOTE]
-> Early-stage but actively deployed — 490 tests, 15 releases, in daily use across Claude.ai, Claude Code, and Claude Desktop. See [Current status](#current-status) for what's working and what's planned.
+> Early-stage but actively deployed — 500 tests, 15 releases, in daily use across Claude.ai, Claude Code, and Claude Desktop. See [Current status](#current-status) for what's working and what's planned.
 
 ## What this is
 
@@ -374,7 +374,7 @@ For single-user deployments, secret path + WAF is sufficient. For multi-user, en
 - Secret path auth + Cloudflare WAF for edge-level access control
 - Docker Compose with Postgres, optional Ollama, named Cloudflare Tunnel, or ephemeral quick tunnel
 - Request timing instrumentation and `/health` endpoint
-- 490 tests (all against real Postgres + Ollama in CI), strict type checking, CI pipeline with coverage, QA gate
+- 500 tests (all against real Postgres + Ollama in CI), strict type checking, CI pipeline with coverage, QA gate
 
 ### Not yet implemented
 - Layer 2 (baseline) detection — rolling averages and deviation calculation

--- a/src/mcp_awareness/middleware.py
+++ b/src/mcp_awareness/middleware.py
@@ -19,12 +19,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import pathlib
 from collections.abc import Callable
 from typing import Any
 
 from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
 
 # The health response builder is injected so middleware doesn't depend on server globals.
 HealthBuilder = Callable[[], dict[str, Any]]
@@ -262,6 +265,7 @@ class AuthMiddleware:
         try:
             claims = await asyncio.to_thread(validator.validate, token)
         except Exception:
+            logger.warning("OAuth token validation failed", exc_info=True)
             return None
 
         owner_id = claims["owner_id"]
@@ -322,7 +326,7 @@ class AuthMiddleware:
 
         except Exception:
             # Don't fail the request if user resolution fails
-            pass
+            logger.warning("User resolution failed for owner_id=%s", owner_id, exc_info=True)
 
         return None
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -236,6 +236,90 @@ class TestWellKnownMiddleware:
         assert "/mcp" in data["resource"]
 
     @pytest.mark.anyio
+    async def test_mount_path_included_in_resource_url(self) -> None:
+        """When mount_path is set, resource URL includes it."""
+
+        async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+            pass
+
+        app = WellKnownMiddleware(
+            inner_app,
+            TEST_ISSUER,
+            public_url="https://mcpawareness.com",
+            mount_path="/secret",
+        )
+        scope = {
+            "type": "http",
+            "path": "/.well-known/oauth-protected-resource",
+            "method": "GET",
+            "headers": [],
+        }
+
+        sent: list[dict[str, Any]] = []
+
+        async def noop_receive() -> dict[str, Any]:
+            return {"type": "http.request", "body": b""}
+
+        async def capture_send(msg: dict[str, Any]) -> None:
+            sent.append(msg)
+
+        await app(scope, noop_receive, capture_send)
+
+        body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+        data = json.loads(body)
+        assert data["resource"] == "https://mcpawareness.com/secret/mcp"
+
+    @pytest.mark.anyio
+    async def test_mount_path_in_host_fallback(self) -> None:
+        """Mount path is included in resource URL derived from Host header."""
+
+        async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+            pass
+
+        app = WellKnownMiddleware(inner_app, TEST_ISSUER, mount_path="/my-secret")
+        scope = {
+            "type": "http",
+            "path": "/.well-known/oauth-protected-resource",
+            "method": "GET",
+            "headers": [(b"host", b"example.com")],
+        }
+
+        sent: list[dict[str, Any]] = []
+
+        async def noop_receive() -> dict[str, Any]:
+            return {"type": "http.request", "body": b""}
+
+        async def capture_send(msg: dict[str, Any]) -> None:
+            sent.append(msg)
+
+        await app(scope, noop_receive, capture_send)
+
+        body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+        data = json.loads(body)
+        assert data["resource"] == "https://example.com/my-secret/mcp"
+
+    @pytest.mark.anyio
+    async def test_non_http_passthrough(self) -> None:
+        """Non-HTTP scopes (websocket, lifespan) pass through to inner app."""
+        called = False
+
+        async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+            nonlocal called
+            called = True
+
+        app = WellKnownMiddleware(inner_app, TEST_ISSUER, host="localhost", port=8420)
+        scope = {"type": "lifespan"}
+
+        async def noop_receive() -> dict[str, Any]:
+            return {"type": "lifespan.startup"}
+
+        async def noop_send(msg: dict[str, Any]) -> None:
+            pass
+
+        await app(scope, noop_receive, noop_send)
+        assert called
+
+    @pytest.mark.anyio
     async def test_passes_through_other_paths(self) -> None:
         called = False
 
@@ -528,6 +612,161 @@ class TestDualAuth:
 
         await app(scope, noop_receive, noop_send)
         assert called_with_owner == ["new-user"]
+
+    @pytest.mark.anyio
+    async def test_bearer_case_insensitive(self) -> None:
+        """RFC 7235: 'bearer' scheme is case-insensitive."""
+        secret = "test-secret-at-least-32-chars-long!"
+        token = jwt.encode({"sub": "alice"}, secret, algorithm="HS256")
+
+        called_with_owner: list[str] = []
+
+        async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+            from mcp_awareness.server import _owner_ctx
+
+            called_with_owner.append(_owner_ctx.get())
+
+        app = AuthMiddleware(inner_app, jwt_secret=secret)
+
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "method": "POST",
+            "headers": [(b"authorization", f"bearer {token}".encode())],
+        }
+
+        async def noop_receive() -> dict[str, Any]:
+            return {"type": "http.request", "body": b""}
+
+        async def noop_send(msg: dict[str, Any]) -> None:
+            pass
+
+        await app(scope, noop_receive, noop_send)
+        assert called_with_owner == ["alice"]
+
+    @pytest.mark.anyio
+    async def test_resolve_user_without_oauth_identity(self) -> None:
+        """OAuth claims missing oauth_subject/oauth_issuer skip lookup and link steps."""
+        mock_oauth = MagicMock()
+        mock_oauth.validate.return_value = {
+            "owner_id": "minimal-user",
+            "email": "min@example.com",
+        }
+
+        called_with_owner: list[str] = []
+
+        async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+            from mcp_awareness.server import _owner_ctx
+
+            called_with_owner.append(_owner_ctx.get())
+
+        app = AuthMiddleware(
+            inner_app,
+            jwt_secret="",
+            oauth_validator=mock_oauth,
+            auto_provision=False,
+        )
+
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "method": "POST",
+            "headers": [(b"authorization", b"Bearer oauth-token")],
+        }
+
+        async def noop_receive() -> dict[str, Any]:
+            return {"type": "http.request", "body": b""}
+
+        async def noop_send(msg: dict[str, Any]) -> None:
+            pass
+
+        await app(scope, noop_receive, noop_send)
+        # Falls back to raw owner_id from claims
+        assert called_with_owner == ["minimal-user"]
+
+    @pytest.mark.anyio
+    async def test_try_oauth_logs_validation_failure(self, caplog: Any) -> None:
+        """OAuth validation exceptions are logged at WARNING level."""
+        import logging
+
+        mock_oauth = MagicMock()
+        mock_oauth.validate.side_effect = RuntimeError("JWKS fetch failed")
+
+        sent: list[dict[str, Any]] = []
+
+        async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+            pass
+
+        app = AuthMiddleware(inner_app, jwt_secret="", oauth_validator=mock_oauth)
+
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "method": "POST",
+            "headers": [(b"authorization", b"Bearer bad-token")],
+        }
+
+        async def noop_receive() -> dict[str, Any]:
+            return {"type": "http.request", "body": b""}
+
+        async def capture_send(msg: dict[str, Any]) -> None:
+            sent.append(msg)
+
+        with caplog.at_level(logging.WARNING, logger="mcp_awareness.middleware"):
+            await app(scope, noop_receive, capture_send)
+
+        assert any("OAuth token validation failed" in r.message for r in caplog.records)
+        # Should still return 401
+        response_start = next(m for m in sent if m["type"] == "http.response.start")
+        assert response_start["status"] == 401
+
+    @pytest.mark.anyio
+    async def test_resolve_user_logs_failure(self, monkeypatch: Any, caplog: Any) -> None:
+        """User resolution exceptions are logged at WARNING level."""
+        import logging
+
+        import mcp_awareness.server as server_mod
+
+        broken_store = MagicMock()
+        broken_store.get_user_by_oauth.side_effect = RuntimeError("db down")
+        monkeypatch.setattr(server_mod, "store", broken_store)
+
+        mock_oauth = MagicMock()
+        mock_oauth.validate.return_value = {
+            "owner_id": "log-test-user",
+            "oauth_subject": "sub",
+            "oauth_issuer": TEST_ISSUER,
+        }
+
+        called_with_owner: list[str] = []
+
+        async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+            from mcp_awareness.server import _owner_ctx
+
+            called_with_owner.append(_owner_ctx.get())
+
+        app = AuthMiddleware(
+            inner_app, jwt_secret="", oauth_validator=mock_oauth, auto_provision=False
+        )
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "method": "POST",
+            "headers": [(b"authorization", b"Bearer token")],
+        }
+
+        async def noop_receive() -> dict[str, Any]:
+            return {"type": "http.request", "body": b""}
+
+        async def noop_send(msg: dict[str, Any]) -> None:
+            pass
+
+        with caplog.at_level(logging.WARNING, logger="mcp_awareness.middleware"):
+            await app(scope, noop_receive, noop_send)
+
+        assert any("User resolution failed" in r.message for r in caplog.records)
+        # Request should still succeed with raw owner_id
+        assert called_with_owner == ["log-test-user"]
 
     @pytest.mark.anyio
     async def test_401_includes_www_authenticate(self) -> None:


### PR DESCRIPTION
## Summary
- Add `logger.warning(exc_info=True)` to `_try_oauth` and `_resolve_user` — auth-path exceptions were silently swallowed, invisible to operators
- Close P1 test gaps from code review analysis: Bearer case-insensitive (RFC 7235), WellKnownMiddleware with `mount_path`, WellKnownMiddleware non-HTTP passthrough, `_resolve_user` without `oauth_subject`/`oauth_issuer`, and logging verification for both exception paths
- 490 → 500 tests

## QA

### Prerequisites
- `pip install -e ".[dev]"`
- Deploy to test instance on alternate port (`AWARENESS_PORT=8421`)

### Manual tests (via MCP tools)
1. - [x] **Bearer case-insensitive**: Send request with `authorization: bearer <token>` (lowercase). Should authenticate successfully.
   ```
   curl -H "Authorization: bearer <token>" https://<host>/mcp
   ```
   Expected: 200 (not 401)

2. - [x] **OAuth validation failure logging**: Send request with invalid OAuth token when `OAUTH_ISSUER` is configured. Check server logs.
   Expected: WARNING log line containing "OAuth token validation failed" with traceback

3. - [x] **User resolution failure logging**: Configure OAuth with a store that's temporarily unavailable. Send valid OAuth token.
   Expected: WARNING log line containing "User resolution failed" — request still succeeds with raw owner_id

4. - [x] **WellKnownMiddleware with mount_path**: Set `AWARENESS_MOUNT_PATH=/secret` and `AWARENESS_PUBLIC_URL=https://example.com`. Check `/.well-known/oauth-protected-resource`.
   Expected: `resource` field is `https://example.com/secret/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)