### PR TITLE
Update CLAUDE.md architecture to match current codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - **Auth setup guide** (`docs/auth-setup.md`): JWT authentication, OAuth 2.1, CLI tools reference, user provisioning, WorkOS walkthrough, known limitations
 - **README**: auth/OAuth env vars tables, CLI tools, security section rewritten (4-layer table), test count 383→490, removed stale "not yet implemented" auth line
-- **CLAUDE.md**: architecture section updated with middleware.py, oauth.py, cli.py, multi-tenant design decisions
+- **CLAUDE.md**: architecture file tree updated with all 16 modules (added tools.py, resources.py, prompts.py, helpers.py, migrate.py, instructions.md, sql/), server.py description corrected, mcp-awareness-migrate CLI added
 - **Deployment guide**: security section updated for JWT/OAuth, license footer fixed (Apache 2.0 → AGPL-3.0)
 - **All docs**: branded footer with logo, consistent copyright format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,17 @@ src/mcp_awareness/
 ├── postgres_store.py  # PostgresStore (psycopg, JSONB, GIN indexes, pgvector, user ops)
 ├── embeddings.py      # Embedding provider abstraction (Ollama, Null), text composition, hashing
 ├── collator.py        # Briefing generation: applies suppressions + patterns, composes summary/mention
-├── server.py          # FastMCP server wiring — resources + tools + owner context (contextvars)
+├── server.py          # FastMCP server wiring — initialization, owner context (contextvars), custom prompt sync
+├── tools.py           # MCP tool handlers (29 tools: CRUD, search, lifecycle, analytics)
+├── resources.py       # MCP resource handlers (briefing, status, knowledge, alerts, intentions, activity)
+├── prompts.py         # MCP prompt handlers (briefing, catchup, diagnostics, knowledge-audit, onboarding)
 ├── middleware.py      # ASGI middleware: SecretPath, Health, WellKnown, AuthMiddleware (JWT + OAuth)
 ├── oauth.py           # OAuth 2.1 resource server — JWKS-based token validation for external providers
-└── cli.py             # CLI entry points: mcp-awareness-user, -token, -secret
+├── cli.py             # CLI entry points: mcp-awareness-user, -token, -secret
+├── migrate.py         # Alembic migration CLI (mcp-awareness-migrate entry point)
+├── helpers.py         # Shared utilities: canonical_email, entry type parsing, pagination, timing
+├── instructions.md    # Server instruction text embedded in MCP metadata
+└── sql/               # Externalized SQL queries (one file per operation)
 ```
 
 **Data flow**: Edge processes → tools (`report_status`, `report_alert`) → `store` → `collator.generate_briefing()` → `awareness://briefing` resource
@@ -109,7 +116,7 @@ src/mcp_awareness/
 - Multi-tenant: `owner_id` column on all data tables, threaded via `contextvars.ContextVar` from auth middleware through store/collator. Default owner from `AWARENESS_DEFAULT_OWNER` or `getpass.getuser()`
 - JWT auth: opt-in via `AWARENESS_AUTH_REQUIRED=true`. `AuthMiddleware` validates Bearer tokens, extracts `sub` claim. Dual auth: self-signed JWTs (HS256) + OAuth provider tokens (RS256 via JWKS). Postgres RLS policies as defense-in-depth
 - OAuth 2.1 resource server: provider-agnostic JWKS validation (WorkOS, Auth0, Cloudflare Access, Keycloak). `/.well-known/oauth-protected-resource` serves RFC 9728 metadata. User identity resolved via OAuth lookup → email linking → auto-provisioning
-- CLI tools: `mcp-awareness-user` (add/list/set-password/export/delete), `mcp-awareness-token` (JWT generation), `mcp-awareness-secret` (signing secret). All registered as console_scripts in pyproject.toml
+- CLI tools: `mcp-awareness-user` (add/list/set-password/export/delete), `mcp-awareness-token` (JWT generation), `mcp-awareness-secret` (signing secret), `mcp-awareness-migrate` (Alembic migrations). All registered as console_scripts in pyproject.toml
 
 ## Deployment
 
@@ -138,7 +145,7 @@ If you have access to the awareness MCP server while working on this repo:
 - Package: `mcp-awareness-server` (PyPI)
 - Import: `mcp_awareness`
 - FastMCP name: `mcp-awareness`
-- CLI entry points: `mcp-awareness` (server), `mcp-awareness-user`, `mcp-awareness-token`, `mcp-awareness-secret`
+- CLI entry points: `mcp-awareness` (server), `mcp-awareness-migrate`, `mcp-awareness-user`, `mcp-awareness-token`, `mcp-awareness-secret`
 - Repo: `cmeans/mcp-awareness`
 - Edge daemons are separate repos (e.g., `homelab-edge`) — this repo is only the generic awareness service
 


### PR DESCRIPTION
## Summary
- Architecture file tree updated: added 7 missing modules (`tools.py`, `resources.py`, `prompts.py`, `helpers.py`, `migrate.py`, `instructions.md`, `sql/`)
- `server.py` description corrected: tools and resources were extracted to separate files
- `mcp-awareness-migrate` CLI entry point added to both architecture section and naming section

## QA

### Prerequisites
- None — documentation-only change

### Manual tests (via MCP tools)
1. - [x] **File tree accuracy**: Verify each file listed in the architecture section exists in `src/mcp_awareness/`
   Expected: All 16 listed files/directories exist

2. - [x] **CLI entry points**: Run `mcp-awareness-migrate --help`
   Expected: Shows Alembic migration help

🤖 Generated with [Claude Code](https://claude.com/claude-code)