### PR TITLE
Fix intention lifecycle: transition pending to fired after briefing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Intention lifecycle**: `generate_briefing` now transitions fired intentions from "pending" to "fired" state, preventing them from firing on every subsequent briefing read
 - **Custom prompt sync uses DEFAULT_OWNER**: `_sync_custom_prompts` now queries `DEFAULT_OWNER` instead of the request-scoped `_owner_id()`, preventing User A's prompt sync from leaking into User B's prompt registry in multi-tenant deployments (MEDIUM #14)
 - **Custom prompt sync debounce**: `_sync_custom_prompts` now skips the DB query if called again within 60 seconds, avoiding a round-trip on every `agent_instructions` invocation (MEDIUM #15)
 

--- a/src/mcp_awareness/collator.py
+++ b/src/mcp_awareness/collator.py
@@ -351,6 +351,12 @@ def generate_briefing(store: Store, owner_id: str) -> dict[str, Any]:
     # Evaluate time-based intentions — fire pending intentions whose deliver_at has passed
     fired_intentions = store.get_fired_intentions(owner_id)
     if fired_intentions:
+        # Transition each matched intention from "pending" to "fired" so they
+        # don't fire again on subsequent briefing reads
+        for intention in fired_intentions:
+            store.update_intention_state(
+                owner_id, intention.id, "fired", reason="Delivered via briefing"
+            )
         briefing["fired_intentions"] = [
             {
                 "id": i.id,

--- a/tests/test_collator.py
+++ b/tests/test_collator.py
@@ -842,6 +842,70 @@ class TestGenerateBriefing:
         assert briefing["evaluation"]["intentions_pending"] == 0
         assert "intention" in briefing["summary"].lower()
 
+    def test_fired_intention_transitions_to_fired_state(self, store):
+        """After generate_briefing, fired intentions transition from pending to fired."""
+        from datetime import timedelta
+
+        past = now_utc() - timedelta(hours=1)
+        intention_id = make_id()
+        store.add(
+            TEST_OWNER,
+            Entry(
+                id=intention_id,
+                type=EntryType.INTENTION,
+                source="personal",
+                tags=["errands"],
+                created=now_utc(),
+                expires=None,
+                data={
+                    "goal": "Pick up milk",
+                    "state": "pending",
+                    "deliver_at": past.isoformat(),
+                },
+            ),
+        )
+        # Before briefing: intention is pending
+        pending = store.get_intentions(TEST_OWNER, state="pending")
+        assert any(i.id == intention_id for i in pending)
+
+        generate_briefing(store, TEST_OWNER)
+
+        # After briefing: intention is no longer pending — it transitioned to fired
+        pending_after = store.get_intentions(TEST_OWNER, state="pending")
+        assert not any(i.id == intention_id for i in pending_after)
+        fired_after = store.get_intentions(TEST_OWNER, state="fired")
+        assert any(i.id == intention_id for i in fired_after)
+
+    def test_fired_intention_not_surfaced_on_second_briefing(self, store):
+        """Once an intention fires and transitions, it doesn't appear in subsequent briefings."""
+        from datetime import timedelta
+
+        past = now_utc() - timedelta(hours=1)
+        store.add(
+            TEST_OWNER,
+            Entry(
+                id=make_id(),
+                type=EntryType.INTENTION,
+                source="personal",
+                tags=["errands"],
+                created=now_utc(),
+                expires=None,
+                data={
+                    "goal": "Pick up milk",
+                    "state": "pending",
+                    "deliver_at": past.isoformat(),
+                },
+            ),
+        )
+        # First briefing fires the intention
+        briefing1 = generate_briefing(store, TEST_OWNER)
+        assert len(briefing1.get("fired_intentions", [])) == 1
+
+        # Second briefing should not fire it again
+        briefing2 = generate_briefing(store, TEST_OWNER)
+        assert briefing2.get("fired_intentions") is None
+        assert briefing2["evaluation"]["intentions_fired"] == 0
+
     def test_briefing_no_intentions_when_none_pending(self, store):
         """Briefing doesn't include intentions when none exist."""
         briefing = generate_briefing(store, TEST_OWNER)


### PR DESCRIPTION
## Summary
- **Bug**: `generate_briefing` called `get_fired_intentions` to surface matching intentions but never called `update_intention_state`, leaving them in "pending" state indefinitely — they fired on every briefing read
- **Fix**: After `get_fired_intentions` returns results, call `update_intention_state` to transition each intention from "pending" to "fired" with reason "Delivered via briefing"
- **Tests**: Added two new integration tests verifying state transition and no repeat firing on subsequent briefings

## Test plan
- [x] `test_fired_intention_transitions_to_fired_state` — confirms intention moves from pending to fired after `generate_briefing`
- [x] `test_fired_intention_not_surfaced_on_second_briefing` — confirms a second `generate_briefing` call does not re-fire the same intention
- [x] All 529 existing tests pass
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean

## QA

### Prerequisites
- `pip install -e ".[dev]"`
- Deploy to test instance on alternate port (`AWARENESS_PORT=8421`)

### Manual tests (via MCP tools)
1. - [x] **Create a time-based intention with deliver_at in the past**
   ```
   remind(goal="Test intention firing", deliver_at="2026-03-29T00:00:00Z", source="test", tags=["qa"])
   ```
   Expected: intention created in pending state

2. - [x] **Read the briefing to trigger firing**
   ```
   get_briefing()
   ```
   Expected: briefing includes `fired_intentions` with the test intention

3. - [x] **Verify intention state transitioned**
   ```
   get_intentions(state="fired")
   ```
   Expected: the test intention appears with state "fired"

4. - [x] **Read briefing again — intention should not re-fire**
   ```
   get_briefing()
   ```
   Expected: briefing does NOT include `fired_intentions` (or they are empty)

5. - [x] **Verify no pending intentions remain for the test**
   ```
   get_intentions(state="pending", tags=["qa"])
   ```
   Expected: empty list (the intention is now fired, not pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
