### PR TITLE
infra: add QA Docker Compose stack with Postgres + Ollama

### DIFF
--- a/docker-compose.qa.yaml
+++ b/docker-compose.qa.yaml
@@ -1,0 +1,100 @@
+# QA testing stack — isolated database, Ollama embeddings, builds from local source
+# Usage:
+#   docker compose -f docker-compose.qa.yaml up -d --build
+#   docker compose -f docker-compose.qa.yaml down -v   # tear down + delete data
+#
+# MCP endpoint: http://localhost:8421/mcp
+# Health check:  curl -s http://localhost:8421/health | python3 -m json.tool
+#
+# Test via Claude Code:
+#   claude -p "<prompt>" \
+#     --mcp-config /tmp/mcp-awareness-qa/mcp-qa.json \
+#     --allowedTools "mcp__awareness-qa__*" \
+#     --output-format text
+name: mcp-awareness-qa
+
+services:
+  mcp-awareness-qa:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: mcp-awareness-qa
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8421:8420"
+    environment:
+      AWARENESS_DATABASE_URL: postgresql://awareness:awareness-qa@postgres-qa:5432/awareness_qa
+      AWARENESS_TRANSPORT: streamable-http
+      AWARENESS_HOST: "0.0.0.0"
+      AWARENESS_PORT: "8420"
+      AWARENESS_EMBEDDING_PROVIDER: ollama
+      AWARENESS_EMBEDDING_MODEL: nomic-embed-text
+      AWARENESS_OLLAMA_URL: http://ollama-qa:11434
+    depends_on:
+      postgres-qa:
+        condition: service_healthy
+      ollama-qa:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s = socket.create_connection(('localhost', 8420), timeout=2); s.close()"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  postgres-qa:
+    image: pgvector/pgvector:pg17
+    container_name: awareness-postgres-qa
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: awareness_qa
+      POSTGRES_USER: awareness
+      POSTGRES_PASSWORD: awareness-qa
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8 --lc-collate=C --lc-ctype=C"
+    volumes:
+      - awareness-qa-pg:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U awareness"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  ollama-qa:
+    image: ollama/ollama:latest
+    container_name: awareness-ollama-qa
+    restart: unless-stopped
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        ollama serve &
+        until ollama list > /dev/null 2>&1; do sleep 1; done
+        ollama pull nomic-embed-text
+        wait
+    volumes:
+      - awareness-qa-ollama:/root/.ollama
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 2G
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list | grep -q nomic-embed-text"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
+volumes:
+  awareness-qa-pg:
+  awareness-qa-ollama:

--- a/docker-compose.qa.yaml
+++ b/docker-compose.qa.yaml
@@ -71,7 +71,7 @@ services:
       start_period: 10s
 
   ollama-qa:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.19.0
     container_name: awareness-ollama-qa
     restart: unless-stopped
     entrypoint: ["/bin/sh", "-c"]

--- a/docker-compose.qa.yaml
+++ b/docker-compose.qa.yaml
@@ -30,6 +30,7 @@ services:
       AWARENESS_EMBEDDING_PROVIDER: ollama
       AWARENESS_EMBEDDING_MODEL: nomic-embed-text
       AWARENESS_OLLAMA_URL: http://ollama-qa:11434
+      AWARENESS_DEFAULT_OWNER: qa
     depends_on:
       postgres-qa:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Self-contained QA testing environment with full embedding support:
- **Postgres** (pgvector/pg17) — isolated `awareness_qa` database, UTF-8, named volume
- **Ollama** (nomic-embed-text) — auto-pulls model on first start, cached in volume
- **mcp-awareness** — built from local source, port 8421 (alongside production on 8420)

One command up, one command teardown. No more ad-hoc `docker run` commands for QA.

## Usage

```bash
# Stand up
docker compose -f docker-compose.qa.yaml up -d --build

# Test
curl -s http://localhost:8421/health | python3 -m json.tool

# Tear down (deletes data)
docker compose -f docker-compose.qa.yaml down -v
```

## QA

### Verified
1. - [x] Stack starts cleanly (Postgres healthy → Ollama healthy → app starts)
2. - [x] Health endpoint responds on port 8421
3. - [x] `remember` creates entries
4. - [x] `semantic_search` returns results with similarity scores (Ollama embeddings working)
5. - [x] `down -v` tears down cleanly (containers, volumes, network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)